### PR TITLE
Add product formatting option

### DIFF
--- a/channel_importer.py
+++ b/channel_importer.py
@@ -5,12 +5,13 @@ import json
 import os
 import re
 import shlex
+import product_formatter
 
 @nightyScript(
     name="Channel Importer",
     author="thedorekaczynski",
     description="Importa mensajes de un canal a otro con opciones de filtrado y reemplazo.",
-    usage="<p>importmsgs --source <src_id> --dest <dest_id> [--limit <n>] [--skip word1,word2] [--replace old=new,...] [--remove-lines 1,2] [--omit-lines-with w1,w2] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--include-files] [--signature text] [--mention-role id1,id2]"
+    usage="<p>importmsgs --source <src_id> --dest <dest_id> [--limit <n>] [--skip word1,word2] [--replace old=new,...] [--remove-lines 1,2] [--omit-lines-with w1,w2] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--include-files] [--signature text] [--mention-role id1,id2] [--format-product]"
 )
 def channel_importer():
     """
@@ -19,9 +20,9 @@ def channel_importer():
     Copia mensajes de un canal de Discord a otro con filtros personalizables.
 
     COMMANDS:
-        <p>importmsgs --source <src_id> --dest <dest_id> [--limit <n>] [--skip w1,w2] [--replace old=new] [--remove-lines 1,2] [--omit-lines-with w1,w2] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--include-files] [--signature text]
+        <p>importmsgs --source <src_id> --dest <dest_id> [--limit <n>] [--skip w1,w2] [--replace old=new] [--remove-lines 1,2] [--omit-lines-with w1,w2] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--include-files] [--signature text] [--format-product]
         <p>importmsgs stop
-        <p>scheduleimport --source <src_id> --dest <dest_id> [opciones] [--interval h]
+        <p>scheduleimport --source <src_id> --dest <dest_id> [opciones] [--interval h] [--format-product]
         <p>stopimport [--source <src_id> --dest <dest_id>]
         <p>status
         <p>rolepost --channel <id> --role <role_id> --emoji 🙂 [--role id2 --emoji :grinning: ...] --text "mensaje"
@@ -39,13 +40,16 @@ def channel_importer():
             --include-files       Adjuntar también los archivos de cada mensaje.
             --signature text      Añadir esta firma al final de cada mensaje copiado.
             --mention-role id1,id2 Menciona estos roles al enviar cada mensaje importado.
+            --format-product      Formatear cada mensaje como producto.
     - Puedes ejecutar `scheduleimport` varias veces para programar importaciones de distintos canales simultáneamente. Usa `stopimport` con los IDs para cancelar una en particular o sin argumentos para detenerlas todas.
 
     EXAMPLES:
         <p>importmsgs --source 123 --dest 456 --skip spam --replace hola=hi --include-files
         <p>importmsgs --source 111 --dest 222 --limit 20 --remove-lines 1 --after 2024-01-01 --signature "Copiado"
         .importmsgs --source 1162281353216262154 --dest 1379868551367757935 --replace Goshippro=Hause --remove-lines 8 --limit 1 --include-files
+        <p>importmsgs --source 321 --dest 654 --format-product
         <p>scheduleimport --source 123 --dest 456 --interval 24 --include-files
+        <p>scheduleimport --source 999 --dest 888 --format-product
         <p>importmsgs stop
         <p>rolepost --channel 123 --role 789 --emoji 👍 --role 1011 --emoji 🔥 --text "Acepta las reglas"
         <p>loadrolepost --message 123456789012345678
@@ -137,6 +141,7 @@ def channel_importer():
         include_files = False
         signature = ""
         mention_roles = []
+        format_product = False
         error = None
 
         def consume_option(opt: str):
@@ -159,6 +164,9 @@ def channel_importer():
         after_val = consume_option('--after')
         before_val = consume_option('--before')
         sig_val = consume_option('--signature')
+        if '--format-product' in parts:
+            format_product = True
+            parts.remove('--format-product')
         if '--include-files' in parts:
             include_files = True
             parts.remove('--include-files')
@@ -218,6 +226,7 @@ def channel_importer():
             'include_files': include_files,
             'signature': signature,
             'mention_roles': mention_roles,
+            'format_product': format_product,
         }, error
 
     async def do_import(opts, ctx=None):
@@ -239,6 +248,8 @@ def channel_importer():
                 text = remove_lines_with_words(text, opts['omit_words'])
                 for old, new in opts['replacements'].items():
                     text = re.sub(re.escape(old), new, text, flags=re.IGNORECASE)
+                if opts.get('format_product'):
+                    text = await product_formatter.format_description(text)
                 trend_line = f"Tendencia [{get_message_date(msg)}]"
                 if opts['signature']:
                     text = f"{text}\n{opts['signature']}" if text else opts['signature']
@@ -334,7 +345,7 @@ def channel_importer():
     @bot.command(
         name="importmsgs",
         description="Importa mensajes de un canal a otro con filtros opcionales.",
-        usage="--source <src_id> --dest <dest_id> [--limit <n>] [--skip w1,w2] [--replace old=new] [--remove-lines 1,2] [--omit-lines-with w1,w2] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--include-files] [--signature text] [--mention-role id1,id2]"
+        usage="--source <src_id> --dest <dest_id> [--limit <n>] [--skip w1,w2] [--replace old=new] [--remove-lines 1,2] [--omit-lines-with w1,w2] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--include-files] [--signature text] [--mention-role id1,id2] [--format-product]"
     )
     async def importmsgs(ctx, *, args: str):
         await ctx.message.delete()
@@ -360,7 +371,7 @@ def channel_importer():
     @bot.command(
         name="scheduleimport",
         description="Programa la importación periódica de mensajes.",
-        usage="--source <src_id> --dest <dest_id> [opciones] [--interval h]"
+        usage="--source <src_id> --dest <dest_id> [opciones] [--interval h] [--format-product]"
     )
     async def scheduleimport(ctx, *, args: str):
         await ctx.message.delete()

--- a/product_formatter.py
+++ b/product_formatter.py
@@ -120,6 +120,35 @@ def product_formatter():
             parts.append(p)
         return " ".join(parts)
 
+    # expose helper
+    globals()["remove_price_sections"] = remove_price_sections
+
+    async def format_description(text: str) -> str:
+        """Return a formatted product description."""
+        if not text.strip():
+            return ""
+
+        cleaned = re.sub(r"\b\d{4}[-/]\d{2}[-/]\d{2}\b", "", text)
+        cleaned = re.sub(r"Keyword.*$", "", cleaned, flags=re.I | re.S).strip()
+        price_info = parse_prices(cleaned)
+        title = remove_price_sections(cleaned, price_info.keys()).strip()
+        category = await run_in_thread(
+            call_mcp,
+            f"Categorize this product title: {title}. Only return the category."
+        )
+
+        lines = [f"**{title}**", f"_Category: {category}_", ""]
+        for code, vals in price_info.items():
+            flag = FLAG_MAP.get(code, code)
+            shipping = (
+                f" + {vals['shipping']} shipping" if vals['shipping'] != "N/A" else ""
+            )
+            lines.append(f"{flag} {vals['price']}{shipping}")
+        return "\n".join(lines)
+
+    # expose for external use
+    globals()["format_description"] = format_description
+
     @bot.command(
         name="formatproduct",
         description="Format a raw product description",
@@ -127,21 +156,10 @@ def product_formatter():
     )
     async def formatproduct(ctx, *, args: str):
         await ctx.message.delete()
-        if not args.strip():
+        result = await format_description(args)
+        if not result:
             await ctx.send("Provide a description.")
             return
-
-        cleaned = re.sub(r"\b\d{4}[-/]\d{2}[-/]\d{2}\b", "", args)
-        cleaned = re.sub(r"Keyword.*$", "", cleaned, flags=re.I | re.S).strip()
-        price_info = parse_prices(cleaned)
-        title = remove_price_sections(cleaned, price_info.keys()).strip()
-        category = await run_in_thread(call_mcp, f"Categorize this product title: {title}. Only return the category.")
-
-        lines = [f"**{title}**", f"_Category: {category}_", ""]
-        for code, vals in price_info.items():
-            flag = FLAG_MAP.get(code, code)
-            shipping = f" + {vals['shipping']} shipping" if vals['shipping'] != "N/A" else ""
-            lines.append(f"{flag} {vals['price']}{shipping}")
-        await ctx.send("\n".join(lines))
+        await ctx.send(result)
 
 product_formatter()

--- a/tests/test_channel_importer.py
+++ b/tests/test_channel_importer.py
@@ -1,0 +1,98 @@
+import builtins
+import importlib
+import sys
+import types
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+builtins.nightyScript = lambda *a, **k: (lambda f: f)
+_captured = {}
+
+class FakeChannel:
+    def __init__(self, messages=None):
+        self.messages = messages or []
+        self.sent = []
+
+    def history(self, limit=None, oldest_first=True, after=None, before=None):
+        async def gen():
+            for m in self.messages:
+                yield m
+        return gen()
+
+    async def send(self, content=None, files=None):
+        self.sent.append((content, files))
+
+class FakeBot:
+    def __init__(self, channels):
+        self.channels = channels
+    def command(self, *a, **k):
+        name = k.get('name') if k else None
+        def dec(f):
+            if name:
+                _captured[name] = f
+            return f
+        return dec
+    def event(self, func):
+        return func
+    def get_channel(self, cid):
+        return self.channels.get(cid)
+
+class FakeMessage:
+    def __init__(self, content):
+        self.content = content
+        self.attachments = []
+        self.created_at = datetime(2024, 1, 1)
+
+# stub modules used by product_formatter
+sys.modules['requests'] = types.ModuleType('requests')
+sys.modules['discord'] = types.ModuleType('discord')
+sys.modules['emoji'] = types.ModuleType('emoji')
+sys.modules['emoji'].emojize = lambda val, language=None: val
+
+channels = {1: FakeChannel([FakeMessage("Test product")]), 2: FakeChannel()}
+
+builtins.bot = FakeBot(channels)
+
+# ensure repo root on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import product_formatter
+importlib.reload(product_formatter)
+
+async def fake_format(text: str):
+    calls.append(text)
+    return "FORMATTED"
+
+calls = []
+product_formatter.format_description = fake_format
+
+import channel_importer
+importlib.reload(channel_importer)
+
+import_fn = _captured['importmsgs']
+_free = {n: c.cell_contents for n, c in zip(import_fn.__code__.co_freevars, import_fn.__closure__)}
+do_import = _free['do_import']
+
+opts = {
+    'source_id': 1,
+    'dest_id': 2,
+    'limit': 50,
+    'skip_words': [],
+    'replacements': {},
+    'remove_lines': [],
+    'omit_words': [],
+    'after_date': None,
+    'before_date': None,
+    'include_files': False,
+    'signature': '',
+    'mention_roles': [],
+    'format_product': True,
+}
+
+asyncio.run(do_import(opts))
+
+expected = "FORMATTED\nTendencia [2024-01-01]"
+assert channels[2].sent == [(expected, None)]
+assert calls == ["Test product"]
+

--- a/tests/test_formatproduct_helpers.py
+++ b/tests/test_formatproduct_helpers.py
@@ -27,9 +27,7 @@ import product_formatter
 importlib.reload(product_formatter)  # ensure decorator capture
 
 parse_prices = product_formatter.parse_prices
-_formatproduct_fn = _captured['formatproduct']
-_free_vars = {n: c.cell_contents for n, c in zip(_formatproduct_fn.__code__.co_freevars, _formatproduct_fn.__closure__)}
-remove_price_sections = _free_vars['remove_price_sections']
+remove_price_sections = product_formatter.remove_price_sections
 
 
 def _clean_text(text: str) -> str:


### PR DESCRIPTION
## Summary
- expose helper functions and new `format_description` in `product_formatter`
- support `--format-product` in channel importer
- mention new option in command docs with examples
- test importer formatting behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ccc5408c832e96175fbcb206ea7c