### PR TITLE
Improve product_formatter imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ A local server that uses OpenRouter's API to generate code for Nighty scripts. T
    node server.js
    ```
 
+## Python Dependencies
+
+The helper scripts such as `channel_importer.py` and `product_formatter.py`
+require Python 3 with the `requests` library installed. Install it with:
+
+```bash
+pip install requests
+```
+
+If `requests` is not available, product formatting will fall back to a basic
+"Unknown" result when querying the local MCP server.
+
 ## Usage
 
 The server runs on `http://localhost:3000` by default. It accepts POST requests to `/generate` with the following JSON body:

--- a/product_formatter.py
+++ b/product_formatter.py
@@ -5,8 +5,11 @@ from pathlib import Path
 import sys
 import asyncio
 import re
-import requests
-import discord
+try:
+    import requests
+except Exception:  # pragma: no cover - optional dependency
+    requests = None
+
 
 # Ensure this script's directory is on sys.path so sibling modules can be
 # imported even if executed from another location.
@@ -56,11 +59,13 @@ def product_formatter():
         return m.group(1).strip() if m else text.strip()
 
     def call_mcp(prompt: str, model: str = "meta-llama/llama-4-maverick:free") -> str:
+        if requests is None:
+            return "Unknown (requests library not installed)"
         try:
             resp = requests.post(
                 "http://localhost:3000/generate",
                 json={"prompt": prompt, "model": model, "language": "text"},
-                timeout=30
+                timeout=30,
             )
             resp.raise_for_status()
             return clean_block(resp.json().get("output", ""))


### PR DESCRIPTION
## Summary
- make `product_formatter` import `requests` optionally
- remove unused `discord` import
- return an explanatory message when `requests` isn't available
- document Python dependencies in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e4da1ec0832ea64b2d5e174da7a9