### PR TITLE
Handle missing product formatter

### DIFF
--- a/channel_importer.py
+++ b/channel_importer.py
@@ -9,7 +9,6 @@ import json
 import os
 import re
 import shlex
-import product_formatter
 
 # Ensure this script's directory is on sys.path so sibling modules load
 # correctly when executed from elsewhere.
@@ -17,7 +16,10 @@ _MODULE_DIR = Path(__file__).resolve().parent
 if str(_MODULE_DIR) not in sys.path:
     sys.path.insert(0, str(_MODULE_DIR))
 
-import product_formatter
+try:
+    import product_formatter
+except ImportError:  # pragma: no cover - safe fallback if missing
+    product_formatter = None
 
 @nightyScript(
     name="Channel Importer",
@@ -260,7 +262,7 @@ def channel_importer():
                 text = remove_lines_with_words(text, opts['omit_words'])
                 for old, new in opts['replacements'].items():
                     text = re.sub(re.escape(old), new, text, flags=re.IGNORECASE)
-                if opts.get('format_product'):
+                if opts.get('format_product') and product_formatter:
                     text = await product_formatter.format_description(text)
                 trend_line = f"Tendencia [{get_message_date(msg)}]"
                 if opts['signature']:

--- a/product_formatter.py
+++ b/product_formatter.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import sys
 import asyncio
 import re
+import builtins
+import types
 try:
     import requests
 except Exception:  # pragma: no cover - optional dependency
@@ -16,6 +18,12 @@ except Exception:  # pragma: no cover - optional dependency
 _MODULE_DIR = Path(__file__).resolve().parent
 if str(_MODULE_DIR) not in sys.path:
     sys.path.insert(0, str(_MODULE_DIR))
+
+# Provide no-op defaults when running outside Nighty
+if not hasattr(builtins, "nightyScript"):
+    builtins.nightyScript = lambda *a, **k: (lambda f: f)
+if not hasattr(builtins, "bot"):
+    builtins.bot = types.SimpleNamespace(command=lambda *a, **k: (lambda f: f))
 
 @nightyScript(
     name="Product Formatter",
@@ -178,3 +186,6 @@ def product_formatter():
         await ctx.send(result)
 
 product_formatter()
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    pass

--- a/tests/test_channel_importer_missing_pf.py
+++ b/tests/test_channel_importer_missing_pf.py
@@ -1,0 +1,99 @@
+import builtins
+import importlib
+import importlib.util
+import sys
+import types
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+builtins.nightyScript = lambda *a, **k: (lambda f: f)
+_captured = {}
+
+class FakeChannel:
+    def __init__(self, messages=None):
+        self.messages = messages or []
+        self.sent = []
+    def history(self, limit=None, oldest_first=True, after=None, before=None):
+        async def gen():
+            for m in self.messages:
+                yield m
+        return gen()
+    async def send(self, content=None, files=None):
+        self.sent.append((content, files))
+
+class FakeBot:
+    def __init__(self, channels):
+        self.channels = channels
+    def command(self, *a, **k):
+        name = k.get('name') if k else None
+        def dec(f):
+            if name:
+                _captured[name] = f
+            return f
+        return dec
+    def event(self, func):
+        return func
+    def get_channel(self, cid):
+        return self.channels.get(cid)
+
+class FakeMessage:
+    def __init__(self, content):
+        self.content = content
+        self.attachments = []
+        self.created_at = datetime(2024, 1, 1)
+
+# stub dependencies
+sys.modules['requests'] = types.ModuleType('requests')
+sys.modules['discord'] = types.ModuleType('discord')
+sys.modules['emoji'] = types.ModuleType('emoji')
+sys.modules['emoji'].emojize = lambda val, language=None: val
+
+channels = {1: FakeChannel([FakeMessage("Test product")]), 2: FakeChannel()}
+
+builtins.bot = FakeBot(channels)
+
+# ensure repo root on path
+repo = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo))
+
+# force ImportError for product_formatter
+_orig_import = builtins.__import__
+
+def _block_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == 'product_formatter':
+        raise ImportError('disabled')
+    return _orig_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = _block_import
+
+spec = importlib.util.spec_from_file_location('channel_importer', repo / 'channel_importer.py')
+channel_importer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(channel_importer)
+
+builtins.__import__ = _orig_import
+
+import_fn = _captured['importmsgs']
+_free = {n: c.cell_contents for n, c in zip(import_fn.__code__.co_freevars, import_fn.__closure__)}
+do_import = _free['do_import']
+
+opts = {
+    'source_id': 1,
+    'dest_id': 2,
+    'limit': 50,
+    'skip_words': [],
+    'replacements': {},
+    'remove_lines': [],
+    'omit_words': [],
+    'after_date': None,
+    'before_date': None,
+    'include_files': False,
+    'signature': '',
+    'mention_roles': [],
+    'format_product': True,
+}
+
+asyncio.run(do_import(opts))
+
+expected = "Test product\nTendencia [2024-01-01]"
+assert channels[2].sent == [(expected, None)]


### PR DESCRIPTION
## Summary
- avoid crash when `product_formatter` isn't available in `channel_importer`
- add regression test ensuring import works without the formatter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842ea5133d4832e9677d9d9ddf23285