### PR TITLE
Add log helper for Nighty print patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ pip install requests
 If `requests` is not available, product formatting will fall back to a basic
 "Unknown" result when querying the local MCP server.
 
+## Logging Helper
+
+Nighty may patch Python's ``print`` to accept a ``type_`` parameter for
+log levels. The helper scripts therefore use a ``log(msg, type_)`` wrapper
+which calls ``print`` normally when that parameter is unsupported.
+
 ## Usage
 
 The server runs on `http://localhost:3000` by default. It accepts POST requests to `/generate` with the following JSON body:

--- a/channel_importer.py
+++ b/channel_importer.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import shlex
+from logging_helper import log
 
 # Ensure this script's directory is on sys.path so sibling modules load
 # correctly when executed from elsewhere.
@@ -282,7 +283,7 @@ def channel_importer():
                         except asyncio.CancelledError:
                             raise
                         except Exception as e:
-                            print(f"Error leyendo adjunto: {e}", type_="ERROR")
+                            log(f"Error leyendo adjunto: {e}", type_="ERROR")
                 msgs.append((text, files))
                 if latest_time is None or msg.created_at > latest_time:
                     latest_time = msg.created_at
@@ -305,7 +306,7 @@ def channel_importer():
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:
-                    print(f"Error enviando mensaje: {e}", type_="ERROR")
+                    log(f"Error enviando mensaje: {e}", type_="ERROR")
                     await asyncio.sleep(1)
 
         if latest_time:

--- a/generate_code.py
+++ b/generate_code.py
@@ -3,6 +3,7 @@ import requests               # synchronous HTTP client
 import asyncio
 import discord
 import re
+from logging_helper import log
 
 
 @nightyScript(
@@ -106,7 +107,7 @@ def generate_code_script():
         output = await run_in_thread(post_to_mcp, prompt_full, model, language)
         
         # Log output details
-        print(f"Output length: {len(output)} characters", type_="INFO")
+        log(f"Output length: {len(output)} characters", type_="INFO")
 
         # Discord has a 2000 character limit per message
         # We'll use 1900 to be safe and account for the code block markers
@@ -116,7 +117,7 @@ def generate_code_script():
             # For longer outputs, save as a file
             temp = Path(getScriptsPath()) / "generated.py"
             temp.write_text(output, encoding="utf-8")
-            print(f"Saved output to {temp} ({len(output)} characters)", type_="INFO")
+            log(f"Saved output to {temp} ({len(output)} characters)", type_="INFO")
             await ctx.send(file=discord.File(str(temp)))
             # Clean up the temporary file
             temp.unlink()

--- a/logging_helper.py
+++ b/logging_helper.py
@@ -1,0 +1,19 @@
+"""Simple logging helper compatible with Nighty.
+
+Nighty patches ``print`` to accept a ``type_`` parameter for log levels.
+This module provides ``log`` that tries to use that parameter when
+available and falls back to a plain ``print`` call otherwise.
+"""
+
+import inspect
+
+_HAS_TYPE_PARAM = 'type_' in inspect.signature(print).parameters
+
+
+def log(msg, type_: str = "INFO") -> None:
+    """Print a message using Nighty's log format when possible."""
+    if _HAS_TYPE_PARAM:
+        print(msg, type_=type_)
+    else:
+        print(msg)
+


### PR DESCRIPTION
## Summary
- introduce `logging_helper.log` wrapper that checks if `print` supports `type_`
- replace direct `print(..., type_=...)` calls with the new helper
- document the log helper in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ea1e1fec832eaec79d6691b09dd7