### PR TITLE
Implement log helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,16 @@ querying the local MCP server.
 
 ## Logging Helper
 
-Nighty may patch Python's ``print`` to accept a ``type_`` parameter for
-log levels. The helper scripts therefore use a ``log(msg, type_)`` wrapper
-which calls ``print`` normally when that parameter is unsupported.
+Nighty may patch Python's ``print`` function to accept a ``type_`` keyword
+for log levels. The ``logging_helper.log`` utility checks for this support
+and falls back to a regular ``print`` call when the keyword is not
+available.
+
+```python
+from logging_helper import log
+
+log("Script initialization complete", type_="INFO")
+```
 
 ## Usage
 

--- a/logging_helper.py
+++ b/logging_helper.py
@@ -5,15 +5,10 @@ This module provides ``log`` that tries to use that parameter when
 available and falls back to a plain ``print`` call otherwise.
 """
 
-import inspect
-
-_HAS_TYPE_PARAM = 'type_' in inspect.signature(print).parameters
-
-
 def log(msg, type_: str = "INFO") -> None:
-    """Print a message using Nighty's log format when possible."""
-    if _HAS_TYPE_PARAM:
+    """Print ``msg`` using the ``type_`` keyword if ``print`` supports it."""
+    try:  # pragma: no cover - depends on Nighty's monkey patching
         print(msg, type_=type_)
-    else:
+    except TypeError:
         print(msg)
 


### PR DESCRIPTION
## Summary
- simplify log helper implementation using a try/except check
- document `logging_helper.log` usage in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843edb27b18832ea777f9c99e7ddb20