### PR TITLE
Update product cleaning rules

### DIFF
--- a/product_formatter.py
+++ b/product_formatter.py
@@ -153,6 +153,8 @@ def product_formatter():
 
         cleaned = re.sub(r"\b\d{4}[-/]\d{2}[-/]\d{2}\b", "", text)
         cleaned = re.sub(r"Keyword.*$", "", cleaned, flags=re.I | re.S).strip()
+        cleaned = cleaned.replace("Goshippro", "Hause")
+        cleaned = re.sub(r"^.*keyword on.*$", "", cleaned, flags=re.I | re.M)
         price_info = parse_prices(cleaned)
         title = remove_price_sections(cleaned, price_info.keys()).strip()
         category = await run_in_thread(

--- a/tests/test_product_formatter.py
+++ b/tests/test_product_formatter.py
@@ -1,5 +1,6 @@
 import builtins
 import importlib
+import re
 import sys
 import types
 from pathlib import Path
@@ -16,6 +17,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import product_formatter
 
 parse_prices = product_formatter.parse_prices
+
+
+def _clean_text(text: str) -> str:
+    text = re.sub(r"\b\d{4}[-/]\d{2}[-/]\d{2}\b", "", text)
+    text = re.sub(r"Keyword.*$", "", text, flags=re.I | re.S).strip()
+    text = text.replace("Goshippro", "Hause")
+    return re.sub(r"^.*keyword on.*$", "", text, flags=re.I | re.M)
 
 
 def test_parse_prices_country_leading():
@@ -43,3 +51,14 @@ def test_parse_prices_mixed_formats():
         "USA": {"price": "$70", "shipping": "$5"},
         "DE": {"price": "€60", "shipping": "N/A"},
     }
+
+
+def test_clean_replaces_goshippro():
+    text = "Buy from Goshippro 2024-07-01"
+    assert _clean_text(text) == "Buy from Hause"
+
+
+def test_clean_removes_keyword_on_line():
+    text = "Line1\nkeyword on sale\nLine2"
+    cleaned = _clean_text(text)
+    assert re.search(r"keyword on", cleaned, re.I) is None


### PR DESCRIPTION
## Summary
- handle Goshippro -> Hause replacement and strip keyword lines
- add new tests for the cleaning logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f9ce7b44832e86315a38bc854cd2