### PR TITLE
Fix parse price regex and add test

### DIFF
--- a/product_formatter.py
+++ b/product_formatter.py
@@ -111,7 +111,7 @@ def product_formatter():
                     continue
 
                 # format 1: "USA $99" (optionally with "shipping $X")
-                m1 = re.match(r"([A-Za-z]{2,3})[^$€£\d]*([$€£]?\d+(?:\.\d+)?)", sub)
+                m1 = re.match(r"^([A-Za-z]{2,3})\b[^$€£\d]*([$€£]?\d+(?:\.\d+)?)", sub)
                 if m1:
                     code = m1.group(1).upper()
                     price = m1.group(2)

--- a/tests/test_product_formatter.py
+++ b/tests/test_product_formatter.py
@@ -62,3 +62,9 @@ def test_clean_removes_keyword_on_line():
     text = "Line1\nkeyword on sale\nLine2"
     cleaned = _clean_text(text)
     assert re.search(r"keyword on", cleaned, re.I) is None
+
+
+def test_parse_prices_ignores_non_country_line():
+    text = "Gross Weight: 0.2kg"
+    result = parse_prices(text)
+    assert result == {}


### PR DESCRIPTION
## Summary
- refine country/price detection regex in `product_formatter`
- add regression test for non-country weight lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843fae582e8832e8937697d0a2ac602