### PR TITLE
Fix country code regex boundary and add weight test

### DIFF
--- a/product_formatter.py
+++ b/product_formatter.py
@@ -113,7 +113,7 @@ def product_formatter():
                     continue
 
                 # format 1: "USA $99" (optionally with "shipping $X")
-                m1 = re.match(r"^([A-Za-z]{2,3})\b[^$€£\d]*([$€£]?\d+(?:\.\d+)?)", sub)
+                m1 = re.match(r"^\b([A-Za-z]{2,3})\b[^$€£\d]*([$€£]?\d+(?:\.\d+)?)", sub)
                 if m1:
                     code = m1.group(1).upper()
                     price = m1.group(2)

--- a/tests/test_product_formatter.py
+++ b/tests/test_product_formatter.py
@@ -77,6 +77,19 @@ def test_parse_prices_ignores_non_country_line():
     assert result == {}
 
 
+def test_parse_prices_ignores_weight_among_prices():
+    text = (
+        "USA $99 shipping $10\n"
+        "Gross Weight: 0.2kg\n"
+        "UK £80 shipping £5"
+    )
+    result = parse_prices(text)
+    assert result == {
+        "USA": {"price": "$99", "shipping": "$10"},
+        "UK": {"price": "£80", "shipping": "£5"},
+    }
+
+
 def test_parse_profits_and_margins():
     text = (
         "USA $99 shipping $10, UK £80 shipping £5\n"


### PR DESCRIPTION
## Summary
- ensure country codes are matched only at word boundaries
- test that `Gross Weight` lines are ignored when parsing prices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ffa5773c832e92878a2529a487a2