### PR TITLE
Add log helper usage

### DIFF
--- a/channel_importer.py
+++ b/channel_importer.py
@@ -310,7 +310,7 @@ def channel_importer():
             if ctx:
                 await ctx.send(f"Error obteniendo mensajes: {e}")
             else:
-                print(f"Error obteniendo mensajes: {e}")
+                log(f"Error obteniendo mensajes: {e}", type_="ERROR")
             return None
 
         for content, files in msgs:


### PR DESCRIPTION
## Summary
- use `log` for error output in `channel_importer`
- keep lightweight logging helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68440ecae40c832ea93ecba5d86269a9