### PR TITLE
Fix code block parsing

### DIFF
--- a/generate_code.py
+++ b/generate_code.py
@@ -53,8 +53,8 @@ def generate_code_script():
         """Clean up the response by removing explanatory text and fixing code blocks."""
         # Remove any explanatory text after the code block
         if "```" in text:
-            # Find the last code block
-            code_blocks = re.findall(r"```(?:python)?\n(.*?)```", text, re.DOTALL)
+            # Find the last fenced block regardless of language identifier
+            code_blocks = re.findall(r"```(?:\w+)?\n(.*?)```", text, re.DOTALL)
             if code_blocks:
                 return code_blocks[-1].strip()
         return text.strip()


### PR DESCRIPTION
## Summary
- fix regex in `generate_code.clean_response` so code blocks are recognized with any language identifier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441859f50c832e9cd03794d57359bd